### PR TITLE
Add test to fs.readFileSync in TypeScript files (#1736)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-bundler",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "index.js",
   "license": "MIT",

--- a/test/integration/typescript-fs/index.ts
+++ b/test/integration/typescript-fs/index.ts
@@ -1,0 +1,7 @@
+import { readFileSync } from 'fs';
+import rawFromTsx from './readFromTsx';
+
+module.exports = {
+  fromTs: readFileSync(__dirname + '/raw.tsx', "utf-8"),
+  fromTsx: rawFromTsx,
+};

--- a/test/integration/typescript-fs/raw.tsx
+++ b/test/integration/typescript-fs/raw.tsx
@@ -1,0 +1,1 @@
+export default <div>Hello</div>;

--- a/test/integration/typescript-fs/readFromTsx.tsx
+++ b/test/integration/typescript-fs/readFromTsx.tsx
@@ -1,0 +1,5 @@
+import { readFileSync } from 'fs';
+
+const raw = readFileSync(__dirname + '/raw.tsx', "utf-8");
+
+export default raw;

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -140,4 +140,18 @@ describe('typescript', function() {
     assert.equal(typeof output.test, 'function');
     assert.equal(output.test(), 'test passed');
   });
+
+  it('fs.readFileSync should inline a file as a string', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-fs/index.ts')
+    );
+
+    const text = 'export default <div>Hello</div>;';
+    let output = await run(b);
+
+    assert.deepEqual(output, {
+      fromTs: text,
+      fromTsx: text
+    });
+  });
 });


### PR DESCRIPTION
---
name: Add test to fs.readFileSync in TypeScript files
---

## 💥 Problem

Inlining file in browser mode doesn't work when in TypeScript files when `fs` is imported with star import or default import. The only way to use `readFileSync` is:
```typescript
import { readFileSync } from 'fs';
const raw = readFileSync(__dirname + '/raw.tsx', 'utf-8');
```

## ↪️ Pull Request
Adds test to `fs.readFileSync` in TypeScript files and thus provides better workaround for #1736.

<!-- ## 💻 Examples Examples help us understand the requested feature better -->

## ✔️ PR Todo
- [ ] Link in all relevant issues.
- [ ] Post reproduction to CodeSandbox.
- [ ] Document that the only (ATM) way of using `fs.readFileSync` is the named import `{ readFileSync }`.
